### PR TITLE
Fix entity field parsing interruption, set version to 1.1.1

### DIFF
--- a/javascript/CLDController.js
+++ b/javascript/CLDController.js
@@ -2,7 +2,7 @@
  * This file is part of Cross-language dialect:
  *     https://github.com/OGStudio/cross-language-dialect
  * License: CC0
- * Version: 1.1.0
+ * Version: 1.1.1
  */
 
 function CLDController(context) {

--- a/kotlin/CLDContext.kt
+++ b/kotlin/CLDContext.kt
@@ -2,7 +2,7 @@
  * This file is part of Cross-language dialect:
  *     https://github.com/OGStudio/cross-language-dialect
  * License: CC0
- * Version: 1.1.0
+ * Version: 1.1.1
  */
 
 package org.opengamestudio

--- a/kotlin/CLDController.kt
+++ b/kotlin/CLDController.kt
@@ -2,7 +2,7 @@
  * This file is part of Cross-language dialect:
  *     https://github.com/OGStudio/cross-language-dialect
  * License: CC0
- * Version: 1.1.0
+ * Version: 1.1.1
  */
 
 package org.opengamestudio
@@ -16,7 +16,7 @@ class CLDController(
     internal var queue = mutableListOf<CLDContext>()
  
     fun executeFunctions() {
-        val c = queue.removeFirst()
+        val c = queue.removeAt(0)
         context.recentField = c.recentField
         context.setField(c.recentField, c.fieldAny(c.recentField))
        

--- a/translator/src/console.kt
+++ b/translator/src/console.kt
@@ -2,7 +2,7 @@
  * This file is part of Cross-language dialect:
  *     https://github.com/OGStudio/cross-language-dialect
  * License: CC0
- * Version: 1.1.0
+ * Version: 1.1.1
  */
 
 package org.opengamestudio

--- a/translator/src/constants.kt
+++ b/translator/src/constants.kt
@@ -2,7 +2,7 @@
  * This file is part of Cross-language dialect:
  *     https://github.com/OGStudio/cross-language-dialect
  * License: CC0
- * Version: 1.1.0
+ * Version: 1.1.1
  */
 
 package org.opengamestudio

--- a/translator/src/fs_jvm.kt
+++ b/translator/src/fs_jvm.kt
@@ -2,7 +2,7 @@
  * This file is part of Cross-language dialect:
  *     https://github.com/OGStudio/cross-language-dialect
  * License: CC0
- * Version: 1.1.0
+ * Version: 1.1.1
  */
 
 package org.opengamestudio

--- a/translator/src/genKotlin.kt
+++ b/translator/src/genKotlin.kt
@@ -2,7 +2,7 @@
  * This file is part of Cross-language dialect:
  *     https://github.com/OGStudio/cross-language-dialect
  * License: CC0
- * Version: 1.1.0
+ * Version: 1.1.1
  */
 
 package org.opengamestudio

--- a/translator/src/other.kt
+++ b/translator/src/other.kt
@@ -2,7 +2,7 @@
  * This file is part of Cross-language dialect:
  *     https://github.com/OGStudio/cross-language-dialect
  * License: CC0
- * Version: 1.1.0
+ * Version: 1.1.1
  */
 
 package org.opengamestudio

--- a/translator/src/parseEntity.kt
+++ b/translator/src/parseEntity.kt
@@ -96,12 +96,14 @@ fun parseEntityFields(lines: Array<String>): Map<Int, Map<String, String>> {
     var isParsingFields = false
 
     for (ln in lines) {
+        println("ИГР parseEF-01 ln: '$ln'")
         val isSectionMarker = (ln == SECTION_FIELDS)
         val isField = isParsingFields && !parseEntityField(ln).isEmpty()
         val isEntityEndMarker = isParsingFields && ln.isEmpty()
         val isLastEntityEndMarker = isParsingFields && (ln == lines.last())
 
         if (isSectionMarker) {
+            println("ИГР parseEF-02 isPF: 'true'")
             isParsingFields = true
         }
 
@@ -116,6 +118,7 @@ fun parseEntityFields(lines: Array<String>): Map<Int, Map<String, String>> {
             isEntityEndMarker ||
             isLastEntityEndMarker
         ) {
+            println("ИГР parseEF-02 isEEM/isLEEM: '$isEntityEndMarker'/'$isLastEntityEndMarker'")
             isParsingFields = false
             d[entityId] = fields
             entityId++

--- a/translator/src/parseEntity.kt
+++ b/translator/src/parseEntity.kt
@@ -2,7 +2,7 @@
  * This file is part of Cross-language dialect:
  *     https://github.com/OGStudio/cross-language-dialect
  * License: CC0
- * Version: 1.1.0
+ * Version: 1.1.1
  */
 
 package org.opengamestudio

--- a/translator/src/parseEntity.kt
+++ b/translator/src/parseEntity.kt
@@ -54,8 +54,6 @@ fun parseEntityFieldComments(lines: Array<String>): Map<Int, Map<String, String>
         val isField = isParsingFields && !parseEntityField(ln).isEmpty()
         val isEntityEndMarker = isParsingFields && ln.isEmpty()
         val isLastEntityEndMarker = isParsingFields && (ln == lines.last())
-        /**/if (isLastEntityEndMarker) {
-        }
 
         if (isSectionMarker) {
             isParsingFields = true
@@ -102,10 +100,8 @@ fun parseEntityFields(lines: Array<String>): Map<Int, Map<String, String>> {
         val isField = isParsingFields && !parseEntityField(ln).isEmpty()
         val isEntityEndMarker = isParsingFields && ln.isEmpty()
         val isLastEntityEndMarker = isParsingFields && (i == lines.size - 1)
-        /**/println("ИГР parseEF-01 ln/isPF/lines.last: '$ln'")
 
         if (isSectionMarker) {
-            /**/println("ИГР parseEF-02 isPF: 'true'")
             isParsingFields = true
         }
 
@@ -120,7 +116,6 @@ fun parseEntityFields(lines: Array<String>): Map<Int, Map<String, String>> {
             isEntityEndMarker ||
             isLastEntityEndMarker
         ) {
-            /**/println("ИГР parseEF-03 isEEM/isLEEM: '$isEntityEndMarker'/'$isLastEntityEndMarker'")
             isParsingFields = false
             d[entityId] = fields
             entityId++

--- a/translator/src/parseEntity.kt
+++ b/translator/src/parseEntity.kt
@@ -54,6 +54,8 @@ fun parseEntityFieldComments(lines: Array<String>): Map<Int, Map<String, String>
         val isField = isParsingFields && !parseEntityField(ln).isEmpty()
         val isEntityEndMarker = isParsingFields && ln.isEmpty()
         val isLastEntityEndMarker = isParsingFields && (ln == lines.last())
+        /**/if (isLastEntityEndMarker) {
+        }
 
         if (isSectionMarker) {
             isParsingFields = true
@@ -95,15 +97,15 @@ fun parseEntityFields(lines: Array<String>): Map<Int, Map<String, String>> {
     var fields = mutableMapOf<String, String>()
     var isParsingFields = false
 
-    for (ln in lines) {
-        println("ИГР parseEF-01 ln: '$ln'")
+    for ((i, ln) in lines.withIndex()) {
         val isSectionMarker = (ln == SECTION_FIELDS)
         val isField = isParsingFields && !parseEntityField(ln).isEmpty()
         val isEntityEndMarker = isParsingFields && ln.isEmpty()
-        val isLastEntityEndMarker = isParsingFields && (ln == lines.last())
+        val isLastEntityEndMarker = isParsingFields && (i == lines.size - 1)
+        /**/println("ИГР parseEF-01 ln/isPF/lines.last: '$ln'")
 
         if (isSectionMarker) {
-            println("ИГР parseEF-02 isPF: 'true'")
+            /**/println("ИГР parseEF-02 isPF: 'true'")
             isParsingFields = true
         }
 
@@ -118,7 +120,7 @@ fun parseEntityFields(lines: Array<String>): Map<Int, Map<String, String>> {
             isEntityEndMarker ||
             isLastEntityEndMarker
         ) {
-            println("ИГР parseEF-02 isEEM/isLEEM: '$isEntityEndMarker'/'$isLastEntityEndMarker'")
+            /**/println("ИГР parseEF-03 isEEM/isLEEM: '$isEntityEndMarker'/'$isLastEntityEndMarker'")
             isParsingFields = false
             d[entityId] = fields
             entityId++

--- a/translator/src/shoulds.kt
+++ b/translator/src/shoulds.kt
@@ -2,7 +2,7 @@
  * This file is part of Cross-language dialect:
  *     https://github.com/OGStudio/cross-language-dialect
  * License: CC0
- * Version: 1.1.0
+ * Version: 1.1.1
  */
 
 package org.opengamestudio

--- a/translator/src/templates.kt
+++ b/translator/src/templates.kt
@@ -2,7 +2,7 @@
  * This file is part of Cross-language dialect:
  *     https://github.com/OGStudio/cross-language-dialect
  * License: CC0
- * Version: 1.1.0
+ * Version: 1.1.1
  */
 
 package org.opengamestudio


### PR DESCRIPTION
* Fix `removeFirst()` [issue for Android](https://www.reddit.com/r/androiddev/comments/1gspjrs/dont_use_kotlins_removefirst_and_removelast_when/)
* Fix interruption when parsing fields in YML
* Consequently, set CLDController/Context versions to 1.1.1